### PR TITLE
test(cli): avoid mutating env slice in withEnvVar helper

### DIFF
--- a/internal/cli/execute_test.go
+++ b/internal/cli/execute_test.go
@@ -1003,5 +1003,5 @@ func withEnvVar(base []string, key, value string) []string {
 			return updated
 		}
 	}
-	return append(base, prefix+value)
+	return append(append([]string{}, base...), prefix+value)
 }


### PR DESCRIPTION
## Summary
- fixes a test helper edge case where appending a missing env var could mutate the caller-provided slice backing array
- updates `withEnvVar` in `internal/cli/execute_test.go` to always return a defensive copy in the append path
- keeps behavior deterministic for tests that reuse or inspect env slices across helper calls

## Why
`append(base, value)` can reuse `base` capacity and mutate shared backing storage. In tests, that can create hidden coupling and order-dependent failures. The updated implementation preserves immutability expectations for helper input.

## Changes
- file: `internal/cli/execute_test.go`
- function: `withEnvVar(base []string, key, value string) []string`
- change:
  - before: `return append(base, prefix+value)`
  - after: `return append(append([]string{}, base...), prefix+value)`

## Validation
- `go test ./internal/cli/...`
- `go test ./internal/cli -run TestAssetsScan_OutputNormalizesIncludeExcludePatterns -count=1`

## Risk
Low. Scope is limited to test helper logic and does not affect production command paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test utilities to improve slice handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->